### PR TITLE
hotfix windows10でrpmで直接インストールすると怒られるので修正

### DIFF
--- a/remote_playbook/roles/php/tasks/main.yml
+++ b/remote_playbook/roles/php/tasks/main.yml
@@ -5,11 +5,15 @@
   changed_when: no
   ignore_errors: yes
 
-- name: install dependencies packages
+- name: install remi repository
+  shell: wget http://rpms.famillecollet.com/enterprise/remi-release-7.rpm && rpm -Uvh remi-release-7.rpm
+  tags: php
+  when: php_is_installed|failed
+
+- name: install epel repository
   yum: name={{ item }}
   with_items: 
     - epel-release
-    - http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
   tags: php
   when: php_is_installed|failed
 


### PR DESCRIPTION
Windows10において、ansibleでremiリポジトリをrpmで直接インストールしようとすると
`connection reset by peer` 
と言われてfailedになってしまいます。
wgetでダウンロードしてから、rpmでインストールという形を取ると問題なくインストールできました。
（cURLを使うとダメなようです）